### PR TITLE
fix: Helm charts set the component request/limit resource based on environment variables

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -12,7 +12,7 @@
   - In the environments mentioned above, only the corresponding ingress rules need to be configured.
 - Requirements：
   - For production environment (recommended): Worker >= 4 vCPU 8 GB of Memory.
-  - For demo environment (minimum): Worker >= 2 vCPU 2 GB of Memory.
+  - For test environment (minimum): Worker >= 2 vCPU 2 GB of Memory.
   - Can access the managed etcd.
   
 ## 2 Install on TKE

--- a/charts/charts/backup-operator/templates/deployment.yaml
+++ b/charts/charts/backup-operator/templates/deployment.yaml
@@ -45,7 +45,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/backup-operator/values.yaml
+++ b/charts/charts/backup-operator/values.yaml
@@ -27,13 +27,21 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
-  requests:
     cpu: 2
     memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/dashboard-api/templates/deployment.yaml
+++ b/charts/charts/dashboard-api/templates/deployment.yaml
@@ -41,7 +41,11 @@ spec:
               containerPort: 8080
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end } }
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/dashboard-api/values.yaml
+++ b/charts/charts/dashboard-api/values.yaml
@@ -31,13 +31,21 @@ service:
   type: NodePort
   port: 80
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
-  requests:
     cpu: 2
     memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/dashboard/templates/deployment.yaml
+++ b/charts/charts/dashboard/templates/deployment.yaml
@@ -35,7 +35,11 @@ spec:
               containerPort: 80
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/dashboard/values.yaml
+++ b/charts/charts/dashboard/values.yaml
@@ -31,13 +31,21 @@ service:
   type: NodePort
   port: 80
 
-resources:
-   limits:
-     cpu: 4
-     memory: 8G
-   requests:
-     cpu: 2
-     memory: 4G
+prodResources:
+  limits:
+    cpu: 2
+    memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/etcd-controller/templates/deployment.yaml
+++ b/charts/charts/etcd-controller/templates/deployment.yaml
@@ -39,7 +39,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/etcd-controller/values.yaml
+++ b/charts/charts/etcd-controller/values.yaml
@@ -27,13 +27,21 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
-  requests:
     cpu: 2
     memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/etcd-operator/templates/deployment.yaml
+++ b/charts/charts/etcd-operator/templates/deployment.yaml
@@ -50,7 +50,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/etcd-operator/values.yaml
+++ b/charts/charts/etcd-operator/values.yaml
@@ -27,13 +27,21 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
+    cpu: 2
+    memory: 4G
   requests:
-    cpu: 1
+    cpu: 500m
     memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/grafana/templates/deployment.yaml
+++ b/charts/charts/grafana/templates/deployment.yaml
@@ -110,7 +110,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /etc/grafana/provisioning/datasources
               name: datasources

--- a/charts/charts/grafana/values.yaml
+++ b/charts/charts/grafana/values.yaml
@@ -34,13 +34,21 @@ service:
   type: NodePort
   port: 80
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
-  requests:
     cpu: 2
     memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/inspection-controller/templates/deployment.yaml
+++ b/charts/charts/inspection-controller/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
               containerPort: 9090
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/charts/inspection-controller/values.yaml
+++ b/charts/charts/inspection-controller/values.yaml
@@ -31,13 +31,21 @@ service:
   type: NodePort
   port: 80
 
-resources:
+prodResources:
   limits:
-    cpu: 4
-    memory: 8G
-  requests:
     cpu: 2
     memory: 4G
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 2G
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 nodeSelector: {}
 

--- a/charts/charts/tapp/templates/deployment.yaml
+++ b/charts/charts/tapp/templates/deployment.yaml
@@ -46,7 +46,11 @@ spec:
             - "--tlsKeyFile=/etc/tapp/certs/server.key"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- if eq .Values.global.env "production" }}
+            {{- toYaml .Values.prodResources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.testResources | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /etc/tapp/certs
               name: tapp-controller-certs

--- a/charts/charts/tapp/values.yaml
+++ b/charts/charts/tapp/values.yaml
@@ -40,13 +40,21 @@ service:
   type: ClusterIP
   port: 443
 
-resources:
+prodResources:
   limits:
     cpu: 1
     memory: 1Gi
   requests:
-    cpu: 1
+    cpu: 500m
     memory: 512Mi
+
+testResources:
+  limits:
+    cpu: 1
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 50Mi
 
 autoscaling:
   enabled: false

--- a/charts/values.test.yaml
+++ b/charts/values.test.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
-  env: production
+  env: test
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/docs/installation/minikube-amd64.md
+++ b/docs/installation/minikube-amd64.md
@@ -4,11 +4,12 @@
 ## 1 Preparation
 
 - Prerequisites
-    - Kubernetes version is between 1.14 and 1.20.
-    - The version of Prometheus Operator is v0.49.0.
+  - Kubernetes version is between 1.14 and 1.20.
+  - The version of Prometheus Operator is v0.49.0.
 - Requirements：
-    - Worker >= 2 vCPU 2 GB of Memory.
-    - Can access the managed etcd.
+  - For production environment (recommended): Worker >= 4 vCPU 8 GB of Memory.
+  - For test environment (minimum): Worker >= 2 vCPU 2 GB of Memory.
+  - Can access the managed etcd.
 
 ## 2 Install Minikube
 
@@ -98,15 +99,27 @@ kube:
 
 ### 3.2 Install
 
-- Install Kstone
+- Create kstone namespace
 
 ``` shell
-cd charts
-
 kubectl create ns kstone
-
-helm install kstone . -n kstone
 ```
+
+- Helm install for production environment
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.yaml
+```
+
+or
+
+- Helm install for test environment
+
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.test.yaml
+```
+
 - Create Ingress Rule
   
 ```shell
@@ -163,10 +176,22 @@ kubectl port-forward deployment/ingress-nginx-controller 8080:80 --namespace ing
 
 ### 3.3 Update
 
+- Helm upgrade for production environment
+
 ``` shell
 cd charts
 
-helm upgrade kstone . -n kstone
+helm upgrade kstone . -n kstone -f values.yaml
+```
+
+or
+
+- Helm upgrade for test environment
+
+``` shell
+cd charts
+
+helm upgrade kstone . -n kstone -f values.test.yaml
 ```
 
 ### 3.4 Uninstall

--- a/docs/installation/minikube-macos.md
+++ b/docs/installation/minikube-macos.md
@@ -3,11 +3,12 @@
 ## 1 Preparation
 
 - Prerequisites
-    - Kubernetes version is between 1.14 and 1.20.
-    - The version of Prometheus Operator is v0.49.0.
+  - Kubernetes version is between 1.14 and 1.20.
+  - The version of Prometheus Operator is v0.49.0.
 - Requirements：
-    - Worker >= 2 vCPU 2 GB of Memory.
-    - Can access the managed etcd.
+  - For production environment (recommended): Worker >= 4 vCPU 8 GB of Memory.
+  - For test environment (minimum): Worker >= 2 vCPU 2 GB of Memory.
+  - Can access the managed etcd.
 
 ## 2 Install Minikube
 
@@ -91,15 +92,27 @@ kube:
 
 ### 3.2 Install
 
-- Install Kstone
+- Create kstone namespace
 
 ``` shell
-cd charts
-
 kubectl create ns kstone
-
-helm install kstone . -n kstone
 ```
+- Helm install for production environment
+
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.yaml
+```
+
+or
+
+- Helm install for test environment
+
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.test.yaml
+```
+
 - Create Ingress Rule
   
 ```shell
@@ -156,10 +169,22 @@ kubectl port-forward deployment/ingress-nginx-controller 8080:80 --namespace ing
 
 ### 3.3 Update
 
+- Helm upgrade for production environment
+
 ``` shell
 cd charts
 
-helm upgrade kstone . -n kstone
+helm upgrade kstone . -n kstone -f values.yaml
+```
+
+or
+
+- Helm upgrade for test environment
+
+``` shell
+cd charts
+
+helm upgrade kstone . -n kstone -f values.test.yaml
 ```
 
 ### 3.4 Uninstall

--- a/docs/installation/tke.md
+++ b/docs/installation/tke.md
@@ -5,12 +5,13 @@
 ## 1 Preparation
 
 - Prerequisites
-    - Kubernetes version is between 1.14 and 1.20.
-    - The version of Prometheus Operator is v0.49.0.
+  - Kubernetes version is between 1.14 and 1.20.
+  - The version of Prometheus Operator is v0.49.0.
 - Apply for a cluster from [TKE](https://cloud.tencent.com/product/tke).
 - Requirements：
-    - Worker >= 4 vCPU 8 GB of Memory.
-    - Can access the managed etcd.
+  - For production environment (recommended): Worker >= 4 vCPU 8 GB of Memory.
+  - For test environment (minimum): Worker >= 2 vCPU 2 GB of Memory.
+  - Can access the managed etcd.
 
 ## 2 Deploy
 
@@ -85,13 +86,25 @@ kube:
 
 ### 2.2 Install
 
-- Helm is
+- Create kstone namespace
+
 ``` shell
-cd charts
-
 kubectl create ns kstone
+```
+- Helm install for production environment
 
-helm install kstone . -n kstone
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.yaml
+```
+
+or
+
+- Helm install for test environment
+
+```shell
+cd charts/
+helm install kstone . -n kstone -f values.test.yaml
 ```
 
 ### 2.3 Update


### PR DESCRIPTION
In case of exceeding cpu and memory resource limitation in minikube, helm chart default resource requests and limits need to be reduced.