### PR TITLE
Fix update ingress annotations

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -18,7 +18,7 @@ ingress:
   enabled: true
   className: ""
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+#    nginx.ingress.kubernetes.io/rewrite-target: /$2
     service.cloud.tencent.com/direct-access: 'false'
     kubernetes.io/ingress.class: qcloud
 #    # lb info


### PR DESCRIPTION
当ingress的annotations开启nginx.ingress.kubernetes.io/rewrite-target: /$2，访问前端页面无法加载。