### PR TITLE
test: add new test case for kstone-etcd-operator cluster

### DIFF
--- a/test/fixtures/manifests/etcd_service.yaml
+++ b/test/fixtures/manifests/etcd_service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: etcd-test
   name: etcd-test-headless
-  namespace: default
+  namespace: kstone
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
What type of PR is this?
/kind test

What this PR does / why we need it:
Add PrintTraceInfo function, in case of cluster not ready, we can have a clue for what happened. 
Add new test for kstone-etcd-operator created cluster.
Refactor test function, so we can reuse it for all kinds of clusters.

Which issue(s) this PR fixes:
Fixes #