### PR TITLE
ci: upgrade to v0.2.0-beta.1

### DIFF
--- a/charts/charts/dashboard/values.yaml
+++ b/charts/charts/dashboard/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: tkestack/kstone-dashboard
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.0-beta.1"
+  tag: "v0.2.0-beta.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/values.test.yaml
+++ b/charts/values.test.yaml
@@ -5,7 +5,7 @@
 global:
   env: test
   kstone:
-    tag: v0.1.0-beta.1
+    tag: v0.2.0-beta.1
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -5,7 +5,7 @@
 global:
   env: production
   kstone:
-    tag: v0.1.0-beta.1
+    tag: v0.2.0-beta.1
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/docs/installation/kubeadm_en.md
+++ b/docs/installation/kubeadm_en.md
@@ -40,7 +40,7 @@ https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-clu
   - Download Helm Repo:
   
 ```bash
-  git clone -b release-0.1 git@github.com:tkestack/kstone.git
+  git clone -b release-0.2 git@github.com:tkestack/kstone.git
   cd kstone
   cd ./charts
 ```

--- a/docs/installation/minikube-amd64.md
+++ b/docs/installation/minikube-amd64.md
@@ -66,7 +66,7 @@ Please refer to [helm installation](https://helm.sh/docs/intro/install/)
 - Download Helm Repo:
 
 ``` shell
-git clone -b release-0.1 git@github.com:tkestack/kstone.git
+git clone -b release-0.2 git@github.com:tkestack/kstone.git
 cd ./charts
 ```
 

--- a/docs/installation/minikube-macos.md
+++ b/docs/installation/minikube-macos.md
@@ -59,7 +59,7 @@ Please refer to [helm installation](https://helm.sh/docs/intro/install/)
 - Download Helm Repo:
 
 ``` shell
-git clone -b release-0.1 git@github.com:tkestack/kstone.git
+git clone -b release-0.2 git@github.com:tkestack/kstone.git
 cd ./charts
 ```
 

--- a/docs/installation/tke.md
+++ b/docs/installation/tke.md
@@ -25,7 +25,7 @@ Please refer to [helm installation](https://helm.sh/docs/intro/install/)
 - Download Helm Repo:
 
 ``` shell
-git clone -b release-0.1 git@github.com:tkestack/kstone.git
+git clone -b release-0.2 git@github.com:tkestack/kstone.git
 cd ./charts
 ```
 


### PR DESCRIPTION
we make incompatible API changes, so we have to upgrade to v0.2.0-beta.1.