### PR TITLE
fix: compatible with existing clusters

### DIFF
--- a/pkg/etcd/client/version.go
+++ b/pkg/etcd/client/version.go
@@ -53,6 +53,11 @@ func GetEtcdClientProvider(
 ) (VersionClient, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
+
+	// compatible with existing clusters
+	if name == "" {
+		name = kstonev1alpha2.EtcdStorageV3
+	}
 	f, found := providers[name]
 
 	klog.V(1).Infof("get provider name %s,status:%t", name, found)


### PR DESCRIPTION
The existing cluster has no cluster.Spec.StorageBackend field. we should default to v3.